### PR TITLE
PR 올릴 시 빌드 테스트 기능 구현

### DIFF
--- a/.github/workflow/pr_build_test.yml
+++ b/.github/workflow/pr_build_test.yml
@@ -1,0 +1,25 @@
+name: PR Build Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
### 관련 이슈

- close #3 

### 작업 요약

- 나중에 배포 에러 방지를 위해 PR 올릴 시 자동으로 build test가 되도록 하였습니다.
- API 연결하면서 env 파일이 생기면 그때 다시 수정하겠습니다!