### PR TITLE
MUI 테마 색상 형식 문자열 버그 수정

### DIFF
--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -6,7 +6,7 @@ const theme = createTheme({
     mode: 'light',
     primary: {
       main: color.brown_light,
-      contrastText: 'white',
+      contrastText: '#ffffff',
     },
     secondary: {
       main: color.gray_dark,


### PR DESCRIPTION
### 관련 이슈

- close #11

### 작업 요약

- 문자열은 MUI가 지원하는 색상 형식이 아니기 때문에 유효한 색상 형식으로 인식하지 못하는 에러가 발생합니다. 따라서 `contrastText` 속성에 문자열 'white'를 색상 코드인 '#ffffff'로 바꿔주었습니다.