### PR TITLE
가로형 뉴스 카드 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['wimg.mk.co.kr', 'img.hankyung.com'],
+  },
+};
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['wimg.mk.co.kr', 'img.hankyung.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'wimg.mk.co.kr',
+      },
+      {
+        protocol: 'https',
+        hostname: 'img.hankyung.com',
+      },
+    ],
   },
 };
 

--- a/src/components/NewsCardHorizontal.tsx
+++ b/src/components/NewsCardHorizontal.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+
+import { Box, Typography } from '@mui/material';
+
+import color from '@/constants/color';
+
+interface NewsCardHorizontalProps {
+  date: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+}
+
+const NewsCardHorizontal = ({ date, title, description, imageUrl }: NewsCardHorizontalProps) => {
+  return (
+    <Box alignItems="center" display="flex" flexDirection="row" height="180px">
+      <Box display="flex" flexDirection="column">
+        <Typography color={color.blue} fontWeight="bold" mb={1} variant="body2">
+          {date}
+        </Typography>
+        <Typography
+          mb={1}
+          sx={{
+            overflow: 'hidden',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            display: '-webkit-box',
+          }}
+          variant="h5"
+        >
+          {title}
+        </Typography>
+        <Typography
+          sx={{
+            overflow: 'hidden',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            display: '-webkit-box',
+          }}
+          variant="body2"
+        >
+          {description}
+        </Typography>
+      </Box>
+      <Box borderRadius={2} height={130} ml={3} mt={2} overflow="hidden" position="relative" width={450}>
+        <Image fill alt="articleImage" src={imageUrl} style={{ objectFit: 'cover' }} />
+      </Box>
+    </Box>
+  );
+};
+
+export default NewsCardHorizontal;

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -22,6 +22,7 @@ const theme = createTheme({
     },
     h2: {
       fontSize: '36px',
+      fontWeight: 'bold',
     },
     h3: {
       fontSize: '30px',
@@ -33,6 +34,7 @@ const theme = createTheme({
     },
     h5: {
       fontSize: '20px',
+      fontWeight: 'bold',
     },
     subtitle1: {
       fontSize: '12px',


### PR DESCRIPTION
### 관련 이슈

- close #26 

### 작업 요약

- 뉴스레터 페이지의 가로형 뉴스 카드를 구현했습니다.

### 작업 상세 설명

- 제목과 내용 모두 Webkit을 이용해서 2줄이 넘어갈 경우 생략 표시(...)가 되도록 하였습니다.

### 리뷰 요구 사항

- 피그마에서 크기가 정확하지 않아 최대한 비슷하게 구현해보았는데 괜찮은지 확인 부탁드립니다~!
- 다음 코드로 확인해보시면 됩니다!
```tsx
import { Box } from '@mui/material';

import Header from '@/components/Header';
import NewsCardHorizontal from '@/components/NewsCardHorizontal';

const Page = () => {
  return (
    <Box>
      <Header />
      <Box p={15} width="53%">
        <NewsCardHorizontal
          date="2024.06.28."
          description="이랜드 ‘프랑제리’ 식사빵 매출 전년비 22%↑ ‘글루텐 프리’ ‘첨가물 제로’ 건강빵 찾는 소비자한국인의 빵 소비량이 증가하는 가운데 즐겁게 건강을 추구하는 ‘헬시 플레저’ 트렌드가 ..."
          imageUrl="https://wimg.mk.co.kr/news/cms/202407/13/rcv.YNA.20240712.PYH2024071213960001300_P1.jpg"
          title="“빵순이들도 입맛 까다로워졌네”… 달콤한 맛보다 훨씬 잘 팔린다는 이 맛, 뭐길래"
        />
      </Box>
    </Box>
  );
};

export default Page;
```

### 미리 보기
![스크린샷 2024-07-14 030723](https://github.com/user-attachments/assets/75040940-dcac-43f5-bb66-d9b519a6fab3)
![스크린샷 2024-07-14 030707](https://github.com/user-attachments/assets/5c7590ce-4839-48a9-a712-a28868a7cef9)
