### PR TITLE
Noto Sans KR로 적용

### DIFF
--- a/public/fonts.css
+++ b/public/fonts.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+
 @font-face {
   font-family: 'GmarketSansLight';
   src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansLight.woff') format('woff');

--- a/src/components/NewsCardHorizontal.tsx
+++ b/src/components/NewsCardHorizontal.tsx
@@ -15,7 +15,7 @@ const NewsCardHorizontal = ({ date, title, description, imageUrl }: NewsCardHori
   return (
     <Stack alignItems="center" direction="row" height="180px">
       <Stack>
-        <Typography color={color.blue} fontWeight="bold" mb={1} variant="body2">
+        <Typography color={color.blue} fontWeight="600" mb={1} variant="body2">
           {date}
         </Typography>
         <Typography

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -15,7 +15,7 @@ const theme = createTheme({
   },
 
   typography: {
-    fontFamily: 'Noto Sans, sans-serif',
+    fontFamily: 'Noto Sans KR, sans-serif',
     h1: {
       fontSize: '36px',
       fontFamily: 'GmarketSansBold',
@@ -34,7 +34,7 @@ const theme = createTheme({
     },
     h5: {
       fontSize: '20px',
-      fontWeight: 'bold',
+      fontWeight: '800',
     },
     subtitle1: {
       fontSize: '12px',

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -34,7 +34,7 @@ const theme = createTheme({
     },
     h5: {
       fontSize: '20px',
-      fontWeight: '800',
+      fontWeight: 'bold',
     },
     subtitle1: {
       fontSize: '12px',


### PR DESCRIPTION
### 관련 이슈

- close #43

### 작업 요약

- Noto Sans 폰트가 적용되고 있었으나 피그마 디자인대로 적용되지 않던 문제를 한국 버전인 KR로 바꾸어 해결했습니다.

### 미리 보기
- 현재 폰트
![image](https://github.com/user-attachments/assets/23b1bc45-04a8-49fa-80a7-be583292a752)

- 수정된 폰트
![image](https://github.com/user-attachments/assets/de7c20da-aa68-4da8-880f-11e11525c16a)
