### PR TITLE
세로형 뉴스 카드 이미지 선택으로 변경

### DIFF
--- a/src/components/NewsCardVertical.tsx
+++ b/src/components/NewsCardVertical.tsx
@@ -6,13 +6,15 @@ interface NewsCardVerticalProps {
   date: string;
   title: string;
   description: string;
-  imageUrl: string;
+  imageUrl?: string;
 }
 
 const NewsCardVertical = ({ date, title, description, imageUrl }: NewsCardVerticalProps) => {
   return (
     <Card sx={{ maxWidth: 350, boxShadow: 'none' }}>
-      <CardMedia alt="articleImage" component="img" image={imageUrl} sx={{ height: 190, borderRadius: 2 }} />
+      {imageUrl && (
+        <CardMedia alt="articleImage" component="img" image={imageUrl} sx={{ height: 190, borderRadius: 2 }} />
+      )}
       <CardContent>
         <Typography color={color.blue} fontWeight="600" mb={1} variant="body2">
           {date}


### PR DESCRIPTION
### 관련 이슈

- close #50

### 작업 요약

- 세로형 뉴스 카드 컴포넌트에서 이미지는 선택으로 받게 하였습니다~

### 작업 상세 설명

- 인사이트 페이지를 만들 때 이 컴포넌트를 사용하시면 됩니다!

### 미리 보기
![스크린샷 2024-07-18 020843](https://github.com/user-attachments/assets/2d086e82-79af-43ef-951f-4c3ef8421f8d)
