### PR TITLE
뉴스레터 전체 조회 api 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@mui/material": "^5.15.20",
+    "axios": "^1.7.2",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/api/api.ts
+++ b/src/app/api/api.ts
@@ -1,0 +1,63 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, Method } from 'axios';
+
+const SPRING_API_URL = process.env.NEXT_PUBLIC_SPRING_API_URL;
+const FASTAPI_API_URL = process.env.NEXT_PUBLIC_FASTAPI_API_URL;
+
+const springApi: AxiosInstance = axios.create({
+  baseURL: SPRING_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const fastApi: AxiosInstance = axios.create({
+  baseURL: FASTAPI_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const addTokenToHeaders = (config: AxiosRequestConfig, token: string | null): AxiosRequestConfig => {
+  const updatedConfig = { ...config };
+  if (token) {
+    updatedConfig.headers = {
+      ...updatedConfig.headers,
+      Authorization: `Bearer ${token}`,
+    };
+  }
+  return updatedConfig;
+};
+
+const makeRequest = async (
+  apiInstance: AxiosInstance,
+  method: Method,
+  url: string,
+  data: unknown = null,
+  token: string | null = null,
+) => {
+  let config: AxiosRequestConfig = {
+    method,
+    url,
+    data,
+  };
+
+  config = addTokenToHeaders(config, token);
+
+  try {
+    const response: AxiosResponse = await apiInstance(config);
+    return response.data;
+  } catch (error) {
+    let message = '';
+    if (error instanceof Error) message = error.message;
+    else message = String(error);
+    return { body: { message } };
+  }
+};
+
+const springApiRequest = (method: Method, url: string, data: unknown = null, token: string | null = null) =>
+  makeRequest(springApi, method, url, data, token);
+
+const fastApiRequest = (method: Method, url: string, data: unknown = null, token: string | null = null) =>
+  makeRequest(fastApi, method, url, data, token);
+
+export { springApiRequest, fastApiRequest };

--- a/src/app/api/newsletter.ts
+++ b/src/app/api/newsletter.ts
@@ -1,0 +1,8 @@
+import { springApiRequest } from './api';
+
+export const getArticleAll = (token?: string | null) => springApiRequest('GET', '/api/article', null, token);
+
+export const getArticle = (id: number, token?: string | null) =>
+  springApiRequest('GET', `/api/article/detail/${id}`, null, token);
+
+export const getPopularArticle = () => springApiRequest('GET', '/api/article/popular');

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Box, Divider, Stack } from '@mui/material';
 
@@ -10,11 +10,24 @@ import NewsCardHorizontal from '@/components/NewsCardHorizontal';
 import Suggestions from '@/components/Suggestion';
 import { articleCategory } from '@/constants/category';
 import color from '@/constants/color';
-import newsData from '@/mocks/news';
 import suggestionData from '@/mocks/suggestion';
+import { Article } from '@/types';
+
+import { getArticleAll } from '../api/newsletter';
 
 const Page = () => {
   const [selectedTab, setSelectedTab] = useState(articleCategory[0]);
+  const [articles, setArticles] = useState<Article[]>([]);
+
+  useEffect(() => {
+    getArticleAll().then((res) => {
+      if (res.status) {
+        setArticles(res.data);
+      } else {
+        throw res.message;
+      }
+    });
+  }, []);
 
   return (
     <Box>
@@ -25,24 +38,26 @@ const Page = () => {
             {articleCategory.map((tab) => (
               <Box key={tab.value} hidden={tab.value !== selectedTab.value}>
                 {tab.value === selectedTab.value &&
-                  (selectedTab.value === 'all'
-                    ? newsData.map((item) => (
+                  (selectedTab.value === 'ALL'
+                    ? articles.map((item) => (
                         <NewsCardHorizontal
-                          key={item.title}
-                          date={item.date}
-                          description={item.description}
+                          key={item.id}
+                          content={item.content}
+                          id={item.id}
                           imageUrl={item.imageUrl}
+                          publishedAt={item.publishedAt.split('T')[0]}
                           title={item.title}
                         />
                       ))
-                    : newsData
-                        .filter((item) => item.value === tab.value)
+                    : articles
+                        .filter((item) => item.category === tab.value)
                         .map((filteredItem) => (
                           <NewsCardHorizontal
-                            key={filteredItem.title}
-                            date={filteredItem.date}
-                            description={filteredItem.description}
+                            key={filteredItem.id}
+                            content={filteredItem.content}
+                            id={filteredItem.id}
                             imageUrl={filteredItem.imageUrl}
+                            publishedAt={filteredItem.publishedAt.split('T')[0]}
                             title={filteredItem.title}
                           />
                         )))}

--- a/src/components/NewsCardHorizontal.tsx
+++ b/src/components/NewsCardHorizontal.tsx
@@ -1,50 +1,64 @@
 import Image from 'next/image';
 
-import { Box, Stack, Typography } from '@mui/material';
+import { Link, Stack, Typography } from '@mui/material';
 
 import color from '@/constants/color';
 
 interface NewsCardHorizontalProps {
-  date: string;
+  id: number;
   title: string;
-  description: string;
-  imageUrl: string;
+  content: string;
+  publishedAt: string;
+  imageUrl?: string;
 }
 
-const NewsCardHorizontal = ({ date, title, description, imageUrl }: NewsCardHorizontalProps) => {
+const NewsCardHorizontal = ({ id, title, content, publishedAt, imageUrl }: NewsCardHorizontalProps) => {
   return (
-    <Stack alignItems="center" direction="row" height="180px">
+    <Stack alignItems="center" direction="row" height="180px" justifyContent="space-between">
       <Stack>
         <Typography color={color.blue} fontWeight="600" mb={1} variant="body2">
-          {date}
+          {publishedAt}
         </Typography>
-        <Typography
-          mb={1}
-          sx={{
-            overflow: 'hidden',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            display: '-webkit-box',
-          }}
-          variant="h5"
-        >
-          {title}
-        </Typography>
-        <Typography
-          sx={{
-            overflow: 'hidden',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            display: '-webkit-box',
-          }}
-          variant="body2"
-        >
-          {description}
-        </Typography>
+        <Link color="inherit" href={`/newsletter/${id}`} underline="none">
+          <Typography
+            mb={1}
+            sx={{
+              overflow: 'hidden',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              display: '-webkit-box',
+            }}
+            variant="h5"
+          >
+            {title}
+          </Typography>
+          <Typography
+            sx={{
+              overflow: 'hidden',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              display: '-webkit-box',
+            }}
+            variant="body2"
+          >
+            {content}
+          </Typography>
+        </Link>
       </Stack>
-      <Box borderRadius={2} height={130} minWidth={230} ml={3} mt={2} overflow="hidden" position="relative">
-        <Image fill priority alt="articleImage" sizes="100%" src={imageUrl} style={{ objectFit: 'cover' }} />
-      </Box>
+      {imageUrl && (
+        <Link
+          borderRadius={2}
+          height={130}
+          href={`/newsletter/${id}`}
+          minWidth={230}
+          ml={3}
+          mt={2}
+          overflow="hidden"
+          position="relative"
+        >
+          <Image fill priority alt="articleImage" sizes="100%" src={imageUrl} style={{ objectFit: 'cover' }} />
+        </Link>
+      )}
     </Stack>
   );
 };

--- a/src/constants/category.ts
+++ b/src/constants/category.ts
@@ -8,10 +8,10 @@ export const mainCategory = [
 ];
 
 export const articleCategory = [
-  { value: 'all', label: '전체' },
-  { value: 'economy', label: '경제' },
-  { value: 'politics', label: '정치' },
-  { value: 'society', label: '사회' },
-  { value: 'culture', label: '문화' },
-  { value: 'science', label: '과학기술' },
+  { value: 'ALL', label: '전체' },
+  { value: 'ECONOMY_AND_BUSINESS', label: '경제' },
+  { value: 'POLITICS_AND_SOCIETY', label: '정치' },
+  { value: 'TECHNOLOGY_AND_CULTURE', label: '문화' },
+  { value: 'SPORTS_AND_LEISURE', label: '스포츠' },
+  { value: 'OPINION_AND_ANALYSIS', label: '분석' },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+export interface Article {
+  id: number;
+  title: string;
+  content: string;
+  publishedAt: string;
+  imageUrl?: string;
+  viewCount: number;
+  category: string;
+  relatedDocuments?: Document[];
+  isValid: boolean;
+}
+
+export interface Document {
+  id: number;
+  title: string;
+  link: string;
+  snippet: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,11 @@ ast-types-flow@^0.0.8:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -904,6 +909,15 @@ axe-core@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.9.1.tgz#fcd0f4496dad09e0c899b44f6c4bb7848da912ae"
   integrity sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==
+
+axios@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@~3.1.1:
   version "3.1.1"
@@ -1026,6 +1040,13 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1159,6 +1180,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1686,6 +1712,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1700,6 +1731,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2273,6 +2313,18 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
@@ -2558,6 +2610,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
### 관련 이슈

- close #53 

### 작업 요약

- 뉴스레터 전체 조회 api를 연결했습니다.

### 작업 상세 설명

- 카테고리 이름도 같이 수정했습니다.
- 기사의 제목과 본문 및 이미지를 클릭했을 때 기사페이지로 이동하도록 라우팅 처리했습니다.

### 미리 보기
![image](https://github.com/user-attachments/assets/8e86b368-9b38-4f1e-bdcf-7747c414f0c4)
![image](https://github.com/user-attachments/assets/22cd4fa5-7a42-40a0-9c43-7dcc2efeeeea)