### PR TITLE
마을 기사 읽기 페이지 UI작업

### DIFF
--- a/src/app/village/[id]/page.tsx
+++ b/src/app/village/[id]/page.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image';
+
+import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
+
+import CommentCard from '@/components/CommentCard';
+import GradientBox from '@/components/GradientBox';
+import Headline from '@/components/Headline';
+import TooltipText from '@/components/TooltipText';
+import color from '@/constants/color';
+import hiddenGems from '@/mocks/villages';
+
+const Page = async ({ params }: { params: { id: number } }) => {
+  // const article = await getArticle(params.id);
+  // const { data } = article;
+  const village = hiddenGems[params.id];
+
+  return (
+    <GradientBox>
+      <Stack alignItems="center" p={10}>
+        <Box sx={{ maxWidth: '600px' }}>
+          <Box sx={{ marginBottom: '2rem' }}>
+            <Headline title={village.title} />
+          </Box>
+          <Box mt="2.5rem">
+            <Box>
+              {village.imageUrl && (
+                <Image
+                  priority
+                  alt="articleImage"
+                  height={400}
+                  src={village.imageUrl}
+                  style={{ objectFit: 'contain' }}
+                  width={600}
+                />
+              )}
+            </Box>
+            <Card sx={{ marginTop: '2rem', backgroundColor: 'transparent', boxShadow: 'none' }}>
+              <CardContent sx={{ padding: 0 }}>
+                <Typography fontSize="16px" py={2} variant="body2" whiteSpace="pre-line">
+                  {village.content}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Box>
+          <Typography color={color.blue} fontSize="20px" py={2} variant="h3" />
+          <CommentCard isCharacter isChat content="다음에 한번 꼭 방문해보고 싶다 😆" />
+        </Box>
+      </Stack>
+    </GradientBox>
+  );
+};
+
+export default Page;

--- a/src/app/village/[id]/page.tsx
+++ b/src/app/village/[id]/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 
 import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
@@ -5,13 +7,11 @@ import { Box, Card, CardContent, Stack, Typography } from '@mui/material';
 import CommentCard from '@/components/CommentCard';
 import GradientBox from '@/components/GradientBox';
 import Headline from '@/components/Headline';
-import TooltipText from '@/components/TooltipText';
+import KakaoMap from '@/components/KakaoMap';
 import color from '@/constants/color';
 import hiddenGems from '@/mocks/villages';
 
 const Page = async ({ params }: { params: { id: number } }) => {
-  // const article = await getArticle(params.id);
-  // const { data } = article;
   const village = hiddenGems[params.id];
 
   return (
@@ -19,7 +19,7 @@ const Page = async ({ params }: { params: { id: number } }) => {
       <Stack alignItems="center" p={10}>
         <Box sx={{ maxWidth: '600px' }}>
           <Box sx={{ marginBottom: '2rem' }}>
-            <Headline title={village.title} />
+            <Headline title={village.title} uploadDate={village.publishedAt} />
           </Box>
           <Box mt="2.5rem">
             <Box>
@@ -43,9 +43,13 @@ const Page = async ({ params }: { params: { id: number } }) => {
             </Card>
           </Box>
           <Typography color={color.blue} fontSize="20px" py={2} variant="h3" />
-          <CommentCard isCharacter isChat content="다음에 한번 꼭 방문해보고 싶다 😆" />
+          <CommentCard isCharacter isChat content="위치는 여기야📍" />
+          <CommentCard isChat content="다음에 같이 가보자!" />
         </Box>
       </Stack>
+      <Box sx={{ marginTop: -2 }}>
+        <KakaoMap villages={[village]} />
+      </Box>
     </GradientBox>
   );
 };

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -15,7 +15,8 @@ const Headline = ({ title, uploadDate, viewCount, source }: HeadlineProps) => {
       </Typography>
       <Stack alignItems="center" direction="row">
         <Typography variant="h4">
-          {uploadDate || '날짜 없음'} | 조회 {viewCount !== undefined ? viewCount : '0'}회 | {source || '출처 없음'}
+          {uploadDate}
+          {source && ` | 조회 ${viewCount}회 | ${source}`}
         </Typography>
       </Stack>
     </Box>

--- a/src/components/Headline.tsx
+++ b/src/components/Headline.tsx
@@ -2,9 +2,9 @@ import { Box, Typography, Stack } from '@mui/material';
 
 interface HeadlineProps {
   title: string;
-  uploadDate: string;
-  viewCount: number;
-  source: string;
+  uploadDate?: string;
+  viewCount?: number;
+  source?: string;
 }
 
 const Headline = ({ title, uploadDate, viewCount, source }: HeadlineProps) => {
@@ -15,7 +15,7 @@ const Headline = ({ title, uploadDate, viewCount, source }: HeadlineProps) => {
       </Typography>
       <Stack alignItems="center" direction="row">
         <Typography variant="h4">
-          {uploadDate} | 조회 {viewCount}회 | {source}
+          {uploadDate || '날짜 없음'} | 조회 {viewCount !== undefined ? viewCount : '0'}회 | {source || '출처 없음'}
         </Typography>
       </Stack>
     </Box>

--- a/src/mocks/villages.ts
+++ b/src/mocks/villages.ts
@@ -1,4 +1,6 @@
-const hiddenGems = [
+import { Village } from '@/types';
+
+const hiddenGems: Village[] = [
   {
     id: 1,
     title: '정선 아우라지마을',


### PR DESCRIPTION
### 관련 이슈

- close #104 

### 작업 요약

- 마을 기사 읽기 페이지를 구성합니다.

### 작업 상세 설명

- 기존에 기사 읽기 페이지와 크게 다르지 않습니다.
- 헤드라인/밑에 기사 추가

### 리뷰 요구 사항

- 코드 스타일

### 미리 보기
<img width="1510" alt="Screenshot 2024-07-21 at 6 36 19 AM" src="https://github.com/user-attachments/assets/1d5c06cd-05f8-450d-87d9-4dbe2b405c3e">
<img width="1510" alt="Screenshot 2024-07-21 at 6 36 28 AM" src="https://github.com/user-attachments/assets/10ad109c-a4ae-496b-8fff-b9d67c771aa9">

