### PR TITLE
뉴스 이미지 안불러와지는 버그 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,10 @@ const nextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'pimg.mk.co.kr',
+      },
+      {
+        protocol: 'https',
         hostname: 'img.hankyung.com',
       },
       {


### PR DESCRIPTION
### 관련 이슈

- close #117

### 작업 요약

- 기존에 쓰지 않던 새로운 도메인에서 이미지가 불러와지더라구요~ 명시해줘서 해결했습니다!

